### PR TITLE
Pre-format CLI values prior to merge

### DIFF
--- a/lib/bogo-cli/command.rb
+++ b/lib/bogo-cli/command.rb
@@ -93,10 +93,12 @@ module Bogo
         end
         if(config_inst)
           options.delete(:config)
+          defaults_inst = config_class.new(defaults.to_smash)
+          options_inst = config_class.new(options.to_smash)
           @options = config_class.new(
-            defaults.to_smash.deep_merge(
+            defaults_inst.to_smash.deep_merge(
               config_inst.to_smash.deep_merge(
-                options.to_smash
+                options_inst.to_smash
               )
             )
           ).to_smash

--- a/test/specs/command_spec.rb
+++ b/test/specs/command_spec.rb
@@ -93,6 +93,29 @@ describe Bogo::Cli::Command do
         Bogo::Cli::Command.new(@cli, []).send(:config)[:null_value].must_equal 'set'
       end
 
+      it 'should deep merge hash values' do
+        command_class = Class.new(Bogo::Cli::Command)
+        command_class.class_eval do
+          def self.name
+            'MyCommand'
+          end
+          def config_class
+            spec_config_class = Class.new(Bogo::Config)
+            spec_config_class.class_eval do
+              attribute :test, Hash, :coerce => lambda{|x| Hash[*x.split(':')] }
+            end
+            spec_config_class
+          end
+        end
+        command = command_class.new({
+          :test => 'new:item',
+          :config => File.join(File.dirname(__FILE__), 'config', 'test.json')
+        }, {})
+        config = command.send(:config)
+        config[:test][:new].must_equal 'item'
+        config[:test][:name].must_equal 'fubar'
+      end
+
     end
 
     describe 'CLI argument processing' do


### PR DESCRIPTION
Run CLI values through Config class instance to properly
format values if required. This will prevent CLI values from
fully knocking out existing values due to string type.

re: sparkleformation/sfn#121