### PR TITLE
allow showing error backtrace without having to turn on DEBUG output

### DIFF
--- a/lib/bogo-cli/setup.rb
+++ b/lib/bogo-cli/setup.rb
@@ -58,7 +58,7 @@ module Bogo
               err_msg << "\n#{err.original.message}"
             end
             output_error err_msg
-            if ENV["DEBUG"]
+            if ENV["DEBUG"] || ENV["DEBUG_BACKTRACE"]
               output_debug "Stacktrace: #{err.class}: " \
                            "#{err.message}\n#{err.backtrace.join("\n")}"
               if err.respond_to?(:original) && err.original


### PR DESCRIPTION
Fixes https://github.com/spox/bogo-cli/issues/12.

@chrisroberts 

