### PR TITLE
Fix option key format

### DIFF
--- a/lib/bogo-cli/command.rb
+++ b/lib/bogo-cli/command.rb
@@ -181,9 +181,8 @@ module Bogo
               ui.puts result
             end
           end
-        rescue => e
+        rescue
           ui.puts ui.color("error!", :red, :bold)
-          ui.error "Reason - #{e}"
           raise
         end
         true

--- a/lib/bogo-cli/parser.rb
+++ b/lib/bogo-cli/parser.rb
@@ -1,3 +1,4 @@
+require 'bogo'
 require 'forwardable'
 require 'optparse'
 require 'ostruct'
@@ -29,11 +30,13 @@ module Bogo
         end
 
         def assign(key, value)
+          key = key.to_s.gsub("-", "_").to_sym
           @sets[key] = value
           self
         end
 
         def set_default(key, value)
+          key = key.to_s.gsub("-", "_").to_sym
           @defaults[key] = value
           self
         end

--- a/lib/bogo-cli/setup.rb
+++ b/lib/bogo-cli/setup.rb
@@ -39,7 +39,7 @@ module Bogo
               err_msg << "\n#{err.original.message}"
             end
             output_error err_msg
-            if ENV["DEBUG"]
+            if ENV["DEBUG"] || (Command.ui && Command.ui.options[:debug])
               output_debug "Stacktrace: #{err.class}: " \
                            "#{err.message}\n#{err.backtrace.join("\n")}"
               if err.respond_to?(:original) && err.original

--- a/test/specs/command_spec.rb
+++ b/test/specs/command_spec.rb
@@ -81,9 +81,15 @@ describe Bogo::Cli::Command do
       before do
         @cli = Bogo::Cli::Parser.parse do
           on :n, :null_value=, 'Option', :default => 'ohai'
+          on :d, :'dashed-option=', 'Option'
           on :c, :config=, 'Option'
           on :z, :cli_defaulter=, 'Option', :default => 'CLI DEFAULT'
         end
+      end
+
+      it 'should map dashed option to underscored key' do
+        c = Bogo::Cli::Command.new(@cli, ["--dashed-option", "set-value"]).send(:config)
+        _(c[:dashed_option]).must_equal 'set-value'
       end
 
       it 'should provide the default option value' do


### PR DESCRIPTION
When handling long flags with a dash, modify the
key value to replace dashes with underscores when
setting the option values.
